### PR TITLE
Remove `noindex` from redirect HTML

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -21,7 +21,6 @@ HTML_TEMPLATE = """
     <meta charset="utf-8">
     <title>Redirecting...</title>
     <link rel="canonical" href="{url}">
-    <meta name="robots" content="noindex">
     <script>var anchor=window.location.hash.substr(1);location.href="{url}"+(anchor?"#"+anchor:"")</script>
     <meta http-equiv="refresh" content="0; url={url}">
 </head>


### PR DESCRIPTION
fix #65.

See #65 for explanation, and https://github.com/pydantic/logfire/pull/574 and https://github.com/pydantic/pydantic/pull/10777 for the impact of including `noindex`.